### PR TITLE
Support redefining plugins, overrides and rules with a "/" in them

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ if (plugin.configs) {
       selfPlugin.configs[configName].rules = Object.assign({}, config.rules);
       Object.keys(config.rules).forEach(ruleName => {
         if (ruleName.startsWith(`${pluginName}/`)) {
-          selfPlugin.configs[configName].rules[`self${ruleName.slice(ruleName.lastIndexOf('/'))}`] = config.rules[ruleName];
+          selfPlugin.configs[configName].rules[`self${ruleName.slice(ruleName.indexOf('/'))}`] = config.rules[ruleName];
           delete selfPlugin.configs[configName].rules[ruleName];
         }
       });

--- a/index.js
+++ b/index.js
@@ -22,6 +22,10 @@ if (plugin.configs) {
       selfPlugin.configs[configName].extends = [].concat(config.extends)
         .map(extendsName => extendsName.replace(`plugin:${pluginName}/`, 'plugin:self/'));
     }
+    if (config.plugins) {
+      selfPlugin.configs[configName].plugins = [].concat(config.plugins)
+        .map(enabledPluginName => enabledPluginName.replace(pluginName, 'self'));
+    }
     if (config.rules) {
       selfPlugin.configs[configName].rules = Object.assign({}, config.rules);
       Object.keys(config.rules).forEach(ruleName => {

--- a/index.js
+++ b/index.js
@@ -43,8 +43,11 @@ if (plugin.configs) {
     if (config.overrides) {
       selfPlugin.configs[configName].overrides = [].concat(config.overrides)
         .map((override) => {
-          override.rules = createRuleset(override.rules);
-          return override;
+          return Object.assign(
+            {},
+            override,
+            {rules: createRuleset(override.rules)}
+          );
         })
     }
   });

--- a/index.js
+++ b/index.js
@@ -12,6 +12,17 @@ if (pkgName[0] === "@") {
   pluginName = pkgName.replace(/^eslint-plugin-/, '');
 }
 
+function createRuleset(rules) {
+  return Object.keys(rules).reduce((newRules, oldRuleName) => {
+    const newRuleName = oldRuleName.startsWith(`${pluginName}/`)
+      ? `self${oldRuleName.slice(oldRuleName.indexOf('/'))}`
+      : oldRuleName;
+
+    newRules[newRuleName] = rules[oldRuleName];
+    return newRules;
+  }, {});
+}
+
 if (plugin.configs) {
   selfPlugin.configs = Object.assign({}, plugin.configs);
 
@@ -27,13 +38,14 @@ if (plugin.configs) {
         .map(enabledPluginName => enabledPluginName.replace(pluginName, 'self'));
     }
     if (config.rules) {
-      selfPlugin.configs[configName].rules = Object.assign({}, config.rules);
-      Object.keys(config.rules).forEach(ruleName => {
-        if (ruleName.startsWith(`${pluginName}/`)) {
-          selfPlugin.configs[configName].rules[`self${ruleName.slice(ruleName.indexOf('/'))}`] = config.rules[ruleName];
-          delete selfPlugin.configs[configName].rules[ruleName];
-        }
-      });
+      selfPlugin.configs[configName].rules = createRuleset(config.rules);
+    }
+    if (config.overrides) {
+      selfPlugin.configs[configName].overrides = [].concat(config.overrides)
+        .map((override) => {
+          override.rules = createRuleset(override.rules);
+          return override;
+        })
     }
   });
 }


### PR DESCRIPTION
Handle case where a rule name contains a `/`

Previously rule names like `myplugin/folder/rule` would get converted to
`self/rule` - cutting off any folder structure. Slicing at the first `/` rather than the last one shall preserve the full path.

---

Handle cases where a config defined in a plugin enables the plugin. Previously the logic didn't switch plugin names out for 'self'

Consider a plugin named 'myplugin' that is defined like so:

```js
module.exports = {
    rules: {
        'myrule': {/* Imagine a rule here */}
    },
    configs: {
        myconfig: {
            plugins: ['myplugin'],
            rules: {'myplugin/myrule': 'error'}
        }
    }
}
```

Consumers of the plugin can do `extends: ['plugin:myplugin/myconfig]` to enable the plugin and configure its rules.

Prior to this PR trying to use eslint-plugin-self resulted in a "myplugin could not be found" error as references to it were not replaced.


---

Handle cases where rules are defined in an override (e.g. because I only want to enable a rule for typescript files)

Consider a plugin that looks like:

```js
module.exports = {
  rules: {
    'myrule': {}
  },
  configs: {
    myconfig: {
      plugins: ['myplugin'],
      rules: {'myplugin/myrule': 'off'},
      overrides: [
        {
          files: ['*.ts'],
          rules: {'myplugin/myrule': 'error'}
        }
      ]
    }
  }
};
```

Prior to this PR the "myplugin/myrule" rule within the overrides would not be transformed into "self/myrule"