### PR TITLE
Added support for setting a custom path to the directory with the plugin

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,13 @@
 'use strict';
 
-const plugin = require('../..');
+const path = require('path');
+
+const pluginDir = process.env.ESLINT_PLUGIN_SELF_DIR || '../';
+
+const plugin = require(pluginDir);
 const selfPlugin = Object.assign({}, plugin);
 
-const pkgName = require('../../package.json').name;
+const pkgName = require(path.join(pluginDir, '/package.json')).name;
 let pluginName;
 if (pkgName[0] === "@") {
   const matches = pkgName.match(/^(@[^/]+)\/eslint-plugin(?:-(.*))?$/);
@@ -46,7 +50,7 @@ if (plugin.configs) {
           return Object.assign(
             {},
             override,
-            {rules: createRuleset(override.rules)}
+            { rules: createRuleset(override.rules) }
           );
         })
     }


### PR DESCRIPTION
The current plugin does not support monorepositories with yarn.  Because yarn puts all dependencies to the root directory and self plugin don't find custom plugin