### PR TITLE
Support overrides having no rules

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ if (plugin.configs) {
     if (config.overrides) {
       selfPlugin.configs[configName].overrides = [].concat(config.overrides)
         .map((override) => {
+          if (!override.rules) return override;
           return Object.assign(
             {},
             override,


### PR DESCRIPTION
First thanks for your useful plugin @not-an-aardvark :)

With eslint v7 it becomes interesting to have overrides with just a `files` pattern an `extend`
This makes `eslint-plugin-self` support that :)

- [example of lint crashing without patch](https://travis-ci.com/github/AdrieanKhisbe/my-node-libraries/jobs/334233664#L260-L272)
- [hack to be used without the patch](https://github.com/AdrieanKhisbe/my-node-libraries/pull/3/commits/a004bf55f182eb53ec8e4c2c0f888d97c944ca81)
