### PR TITLE
Allow running with plugins that are compatible with ESLint flat config (fixes #8)

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,7 +33,9 @@ if (plugin.configs) {
       selfPlugin.configs[configName].extends = [].concat(config.extends)
         .map(extendsName => extendsName.replace(`plugin:${pluginName}/`, 'plugin:self/'));
     }
-    if (config.plugins) {
+    // The Array.isArray avoids attempting to change the plugins property for
+    // eslint v9 based configurations.
+    if (config.plugins && Array.isArray(config.plugins)) {
       selfPlugin.configs[configName].plugins = [].concat(config.plugins)
         .map(enabledPluginName => enabledPluginName.replace(pluginName, 'self'));
     }


### PR DESCRIPTION
I believe the need for eslint-plugin-self will go away with flat config (I'm still testing that). However, for plugins that are still compatible with the legacy ESLint configuration and with flat config, it would be useful if this plugin could still be run on their configurations when testing with v7/v8.